### PR TITLE
Fix hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here are some ideas to get you started:
   - Quantum Computing
   - AR and VR development
 - 💬 Ask me about algorithms, system design, backend engineering and deep learning inference pipelines.
-- 📫 How to reach me: [twitter](twitter.com/arind_das), [linkedin](www.linkedin.com/in/arind-das), [gitlab](https://gitlab.com/dasarindam.mails)
+- 📫 How to reach me: [twitter](https://twitter.com/arind_das), [linkedin](https://www.linkedin.com/in/arind-das), [gitlab](https://gitlab.com/dasarindam.mails)
 - 😄 Pronouns: He/Him
 - ⚡ Fun fact: The Apollo 11 mission computer required only 4KB of ram. (2048 words to be exact. [\[1\]](https://en.wikipedia.org/wiki/Apollo_Guidance_Computer))
 


### PR DESCRIPTION
Not preceding hyperlinks with `https://` results in wrong target link.

Good day!